### PR TITLE
Allow restore w/o copy

### DIFF
--- a/dotty.py
+++ b/dotty.py
@@ -199,7 +199,7 @@ def main():
     if args.backup or args.sync is not None and 'copy' in js:
         [run_command(command) for command in js['before_bak']]
         [copypath(src, dst, backup=True) for dst, src in js['copy'].items() if dst[0] != '_' and src[0] != '_']
-    if args.restore and 'copy' in js:
+    if args.restore:
         check_sudo()
         if 'install' in js and 'install_cmd' in js:
             for c in js['install']:


### PR DESCRIPTION
Currently, it is not possible to perform a restore action with a config file which does not contain `copy`.

This PR removes the restriction for a config file to have a `copy` key to perform the restore action. This is not necessary at this point as it is checked right before entering the copy part of the restore action.